### PR TITLE
feat: add timeline clips with snap and keyboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@ main{display:flex;flex-wrap:wrap;padding:10px;gap:10px;}
 #timeline{background:#fff;border-radius:8px;padding:10px;margin:10px;box-shadow:0 2px 4px rgba(0,0,0,0.1);} 
 .track{position:relative;height:60px;border-bottom:1px solid #ddd;}
 .clip{position:absolute;height:40px;background:#90caf9;border-radius:4px;color:#000;padding:5px;cursor:move;overflow:hidden;}
+.clip.selected{outline:2px solid #f00;}
 .track-label{position:absolute;left:0;top:0;width:80px;height:100%;background:#eee;display:flex;align-items:center;justify-content:center;font-size:12px;}
 .track-content{margin-left:80px;height:100%;position:relative;}
 #timeline{min-height:260px;}
@@ -158,14 +159,74 @@ function stop(){playing=false;clearInterval(tickInterval);}
 return{start,stop,setTempo:t=>tempo=t,setSwing:s=>swing=s,get time(){return currentBeat;},get tempo(){return tempo;},get swing(){return swing;},get playing(){return playing;},toggleMet:()=>{metOn=!metOn;app.audio.metGain.gain.value=metOn?1:0;}};
 })();
 
+/* TIMELINE */
+app.timeline=(function(){
+ const clips=[];
+ let pxPerBeat=60;
+ let selected=null;
+ const trackNames=['melody','backing','bass','guitar','synth','drums'];
+ function addClip(track,startBeats,lengthBeats,events=[]){
+   const clip={id:'clip'+Math.random().toString(36).slice(2),track,startBeats,lengthBeats,loop:true,events};
+   clips.push(clip);
+   render();
+   return clip;
+ }
+ function snap(){
+   const q=parseFloat(document.getElementById('quantize').value);
+   const denom=q?4/q:0;
+   return 1/(denom||4);
+ }
+ function render(){
+   trackNames.forEach(t=>{
+     const lane=document.querySelector(`.track[data-track="${t}"] .track-content`);
+     if(lane) lane.innerHTML='';
+   });
+   clips.forEach(c=>{
+     const lane=document.querySelector(`.track[data-track="${c.track}"] .track-content`);
+     if(!lane)return;
+     const div=el('div',{class:'clip',"data-id":c.id});
+     if(selected===c)div.classList.add('selected');
+     div.style.left=(c.startBeats*pxPerBeat)+"px";
+     div.style.width=(c.lengthBeats*pxPerBeat)+"px";
+     div.textContent=c.track;
+     lane.appendChild(div);
+     attachHandlers(div,c);
+   });
+ }
+ function attachHandlers(div,clip){
+   div.addEventListener('mousedown',e=>{
+     selected=clip;
+     render();
+     const startX=e.clientX;
+     const origStart=clip.startBeats;
+     const origLen=clip.lengthBeats;
+     const mode=e.offsetX>div.clientWidth-10?'resize':'drag';
+     function move(ev){
+       const dx=(ev.clientX-startX)/pxPerBeat;
+       const s=snap();
+       if(mode==='drag'){
+         let nb=origStart+dx;nb=Math.round(nb/s)*s;clip.startBeats=Math.max(0,nb);
+       }else{
+         let nl=origLen+dx;nl=Math.max(s,nl);nl=Math.round(nl/s)*s;clip.lengthBeats=nl;
+       }
+       render();
+     }
+     function up(){document.removeEventListener('mousemove',move);document.removeEventListener('mouseup',up);}
+     document.addEventListener('mousemove',move);
+     document.addEventListener('mouseup',up);
+   });
+ }
+ function deleteClip(id){const i=clips.findIndex(c=>c.id===id);if(i>=0)clips.splice(i,1);}
+ return{clips,addClip,render,snap,deleteClip,get selected(){return selected;},set selected(v){selected=v;},get pxPerBeat(){return pxPerBeat;},set pxPerBeat(v){pxPerBeat=v;render();}};
+})();
+
 /* RECORDER */
 app.recorder=(function(){
 const tracks={melody:[],backing:[],bass:[],guitar:[],synth:[],drums:[]};
 let recording=false;let recordStart=0;function start(){recording=true;recordStart=app.transport.time;} function stop(){recording=false;}
-function record(track,note,velocity){if(!recording)return;let time=app.transport.time-recordStart;const q=parseFloat(document.getElementById('quantize').value);if(q>0)time=Math.round(time/q)*q;tracks[track].push({time,note,velocity});renderClip(track);}
-function playEvents(beat,playTime,tempo,swing){const q=parseFloat(document.getElementById('quantize').value);const secPerBeat=60/tempo;for(const name in tracks){tracks[name].forEach(ev=>{const t=ev.time;const dur=0.5;if(Math.abs(t-beat)<0.001){let offset=0;if(swing>0&&q>0&&Math.floor((ev.time/q)%2)===1)offset=swing*q;app.audio.playNote(name==='drums'?'lead':name,ev.note,ev.velocity,playTime+offset*secPerBeat,dur);}});}}
-function renderClip(track){const lane=document.querySelector(`.track[data-track="${track}"] .track-content`);if(!lane)return;lane.innerHTML='';tracks[track].forEach(ev=>{const c=el('div',{class:'clip',style:`left:${ev.time*60}px;width:30px;`},track);lane.appendChild(c);});}
-return{start,stop,record,tracks,playEvents,renderClip};
+function record(track,note,velocity){if(!recording)return;let time=app.transport.time-recordStart;const q=parseFloat(document.getElementById('quantize').value);if(q>0)time=Math.round(time/q)*q;tracks[track].push({time,note,velocity});let clip=app.timeline.clips.find(c=>c.track===track);if(!clip)clip=app.timeline.addClip(track,0,4,[]);clip.events.push({time,note,velocity});clip.lengthBeats=Math.max(clip.lengthBeats,time+(q||0.25));app.timeline.render();}
+function playEvents(beat,playTime,tempo,swing){const q=parseFloat(document.getElementById('quantize').value);const secPerBeat=60/tempo;app.timeline.clips.forEach(clip=>{const local=beat-clip.startBeats;if(local<0)return;if(!clip.loop&&local>=clip.lengthBeats)return;const pos=((local%clip.lengthBeats)+clip.lengthBeats)%clip.lengthBeats;clip.events.forEach(ev=>{if(Math.abs(pos-ev.time)<0.001){let offset=0;if(swing>0&&q>0&&Math.floor((ev.time/q)%2)===1)offset=swing*q;app.audio.playNote(clip.track==='drums'?'lead':clip.track,ev.note,ev.velocity,playTime+offset*secPerBeat,0.5);}});});}
+return{start,stop,record,tracks,playEvents,get recording(){return recording;}};
 })();
 
 /* UI SETUP */
@@ -202,6 +263,8 @@ const drums=[
 const drumContainer=document.getElementById('drumPads');drums.forEach(d=>{const b=el('button',{class:'pad',html:d.label});b.addEventListener('mousedown',()=>{const t=app.audio.ctx.currentTime;app.audio.drumMap[d.key](t,getVelocity());app.recorder.record('drums',d.note,getVelocity());});drumContainer.appendChild(b);});
 // Timeline
 const tracks=['melody','backing','bass','guitar','synth','drums'];const timeline=document.getElementById('timeline');tracks.forEach(t=>{const row=el('div',{class:'track',"data-track":t});row.appendChild(el('div',{class:'track-label',html:t}));row.appendChild(el('div',{class:'track-content'}));timeline.appendChild(row);});
+app.timeline.render();
+document.addEventListener('keydown',e=>{const clip=app.timeline.selected;if(!clip)return;const s=app.timeline.snap();if(e.key==='Delete'||e.key==='Backspace'){app.timeline.deleteClip(clip.id);app.timeline.selected=null;app.timeline.render();}else if(e.key==='d'&&(e.metaKey||e.ctrlKey)){const copy=JSON.parse(JSON.stringify(clip));copy.id='clip'+Math.random().toString(36).slice(2);copy.startBeats+=s;app.timeline.clips.push(copy);app.timeline.selected=copy;app.timeline.render();}else if(e.key==='ArrowRight'){clip.startBeats=Math.round((clip.startBeats+s)/s)*s;app.timeline.render();}else if(e.key==='ArrowLeft'){clip.startBeats=Math.max(0,clip.startBeats-s);clip.startBeats=Math.round(clip.startBeats/s)*s;app.timeline.render();}});
 // Transport controls
 const playBtn=document.getElementById('play');playBtn.onclick=()=>{if(app.transport.playing){app.transport.stop();playBtn.textContent='Play';}else{app.transport.start();playBtn.textContent='Stop';}};
 const recBtn=document.getElementById('record');recBtn.onclick=()=>{if(app.recorder.recording){app.recorder.stop();recBtn.textContent='Record';}else{app.recorder.start();recBtn.textContent='Stop Rec';}};
@@ -211,9 +274,9 @@ document.getElementById('swing').onchange=e=>app.transport.setSwing(+e.target.va
 const exportBtn=document.getElementById('exportJSON');
 const importBtn=document.getElementById('importJSON');
 const importFile=document.getElementById('importFile');
-exportBtn.onclick=()=>{const data={bpm:+document.getElementById('bpm').value,key:keySel.value,scale:scaleSel.value,tracks:app.recorder.tracks};const blob=new Blob([JSON.stringify(data)],{type:'application/json'});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download='project.json';a.click();URL.revokeObjectURL(url);};
+exportBtn.onclick=()=>{const data={bpm:+document.getElementById('bpm').value,key:keySel.value,scale:scaleSel.value,tracks:app.recorder.tracks,clips:app.timeline.clips};const blob=new Blob([JSON.stringify(data)],{type:'application/json'});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download='project.json';a.click();URL.revokeObjectURL(url);};
 importBtn.onclick=()=>importFile.click();
-importFile.onchange=e=>{const file=e.target.files[0];if(!file)return;const reader=new FileReader();reader.onload=()=>{const data=JSON.parse(reader.result);document.getElementById('bpm').value=data.bpm;app.transport.setTempo(data.bpm);keySel.value=data.key;scaleSel.value=data.scale;app.recorder.tracks=data.tracks;buildPads();for(const tr in data.tracks){app.recorder.renderClip(tr);} };reader.readAsText(file);};
+importFile.onchange=e=>{const file=e.target.files[0];if(!file)return;const reader=new FileReader();reader.onload=()=>{const data=JSON.parse(reader.result);document.getElementById('bpm').value=data.bpm;app.transport.setTempo(data.bpm);keySel.value=data.key;scaleSel.value=data.scale;app.recorder.tracks=data.tracks;app.timeline.clips=data.clips||[];buildPads();app.timeline.render();};reader.readAsText(file);};
 })();
 
 </script>


### PR DESCRIPTION
## Summary
- add timeline module with draggable, resizable clips that snap to the quantize grid
- loop clip events during playback and allow keyboard deletion, duplication, and nudging
- persist clips in project import/export

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a56364c8333bfe75492e7105b9d